### PR TITLE
return valid width when (px|em|%) are present at the end of the width string for custom blot

### DIFF
--- a/src/OpAttributeSanitizer.ts
+++ b/src/OpAttributeSanitizer.ts
@@ -144,7 +144,7 @@ class OpAttributeSanitizer {
    }
 
    static IsValidWidth(width: string) {
-      return !!width.match(/^[0-9]*$/)
+    return !!width.match(/^[0-9]*(px|em|%)?$/)
    }
 }
 

--- a/test/OpAttributeSanitizer.test.ts
+++ b/test/OpAttributeSanitizer.test.ts
@@ -36,6 +36,12 @@ describe('OpAttributeSanitizer', function () {
     describe('#IsValidWidth()', function() {
         it('should return true if width is valid', function() {
             assert.ok(OpAttributeSanitizer.IsValidWidth('150'));
+            assert.ok(OpAttributeSanitizer.IsValidWidth('100px'));
+            assert.ok(OpAttributeSanitizer.IsValidWidth('150em'));
+            assert.ok(OpAttributeSanitizer.IsValidWidth('10%'));
+            assert.equal(OpAttributeSanitizer.IsValidWidth('250%px'), false);
+            assert.equal(OpAttributeSanitizer.IsValidWidth('250% border-box'), false);
+            assert.equal(OpAttributeSanitizer.IsValidWidth('250.80'), false);
             assert.equal(OpAttributeSanitizer.IsValidWidth('250x'), false);
         });
     });


### PR DESCRIPTION
As the title suggests return valid width when (px|em|%) are concatenated to the width. References this #17. It supports length and percentage value as of now. I can create another PR if you want to support keyword values as well. Allowed width values are taken from this [MDN page](https://developer.mozilla.org/en-US/docs/Web/CSS/width) 

I have added tests to go along with. 