### PR TITLE
Allow numeric values in valid size strings.

### DIFF
--- a/src/OpAttributeSanitizer.ts
+++ b/src/OpAttributeSanitizer.ts
@@ -144,7 +144,7 @@ class OpAttributeSanitizer {
    }
 
    static IsValidSize(size: string) {
-      return !!size.match(/^[a-z\-]{1,20}$/i)
+      return !!size.match(/^[a-z0-9\-]{1,20}$/i)
    }
 
    static IsValidWidth(width: string) {


### PR DESCRIPTION
Previously, a valid size was only allowed to contain alphabetical characters and a dash (e.g. "normal" or "large"). That disallowed sizes such as "25px" or "72 points". Modify the regular expression to allow numeric characters in valid size strings.