### PR TITLE
Inline styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,40 @@ Following shows the parameter formats for `beforeRender` event:
 }
 ```
 
+## Rendering Inline Styles ##
+
+If you are rendering to HTML that you intend to include in an email, using classes and a style sheet are not recommended, as [not all browsers support style sheets](https://www.campaignmonitor.com/css/style-element/style-in-head/).  quill-delta-to-html supports rendering inline styles instead.  The easiest way to enable this is to pass the option `inlineStyles: true`.
+
+You can customize styles by passing an object to `inlineStyles` instead:
+
+```js
+inlineStyles: {
+   font: {
+      'serif': 'font-family: Georgia, Times New Roman, serif',
+      'monospace': 'font-family: Monaco, Courier New, monospace'
+   },
+   size: {
+      'small': 'font-size: 0.75em',
+      'large': 'font-size: 1.5em',
+      'huge': 'font-size: 2.5em'
+   },
+   indent: (value, op) => {
+      var indentSize = parseInt(value, 10) * 3;
+      var side = op.attributes['direction'] === 'rtl' ? 'right' : 'left';
+      return 'padding-' + side + ':' + indentSize + 'em';
+   },
+   direction: (value, op) => {
+      if (value === 'rtl') {
+         return 'direction:rtl' + ( op.attributes['align'] ? '' : '; text-align: inherit' );
+      } else {
+         return '';
+      }
+   }
+};
+```
+
+Keys to this object are the names of attributes from Quill.  The values are either a simple lookup table (like in the 'font' example above) used to map values to styles, or a `fn(value, op)` which returns a style string.
+
 ## Rendering Custom Blot Formats ##
 
 You need to tell system how to render your custom blot by registering a renderer callback function to `renderCustomWith` method before calling the `convert()` method. 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ var html = converter.convert();
 |paragraphTag| 'p' | Custom tag to wrap inline html elements|
 |encodeHtml| true | If true, `<, >, /, ', ", &` characters in content will be encoded.|
 |classPrefix| 'ql' | A css class name to prefix class generating styles such as `size`, `font`, etc. |
+|inlineStyles| false | If true, use inline styles instead of classes |
 |multiLineBlockquote| true | Instead of rendering multiple `blockquote` elements for quotes that are consecutive and have same styles(`align`, `indent`, and `direction`), it renders them into only one|
 |multiLineHeader| true | Same deal as `multiLineBlockquote` for headers|
 |multiLineCodeblock| true | Same deal as `multiLineBlockquote` for code-blocks|

--- a/dist/browser/QuillDeltaToHtmlConverter.bundle.js
+++ b/dist/browser/QuillDeltaToHtmlConverter.bundle.js
@@ -332,6 +332,7 @@ var OpToHtmlConverter = (function () {
         this.op = op;
         this.options = obj.assign({}, {
             classPrefix: 'ql',
+            inlineStyles: false,
             encodeHtml: true,
             listItemTag: 'li',
             paragraphTag: 'p'
@@ -381,6 +382,9 @@ var OpToHtmlConverter = (function () {
     };
     OpToHtmlConverter.prototype.getCssClasses = function () {
         var attrs = this.op.attributes;
+        if (this.options.inlineStyles) {
+            return [];
+        }
         var propsArr = ['indent', 'align', 'direction', 'font', 'size'];
         if (this.options.allowBackgroundClasses) {
             propsArr.push('background');
@@ -395,14 +399,67 @@ var OpToHtmlConverter = (function () {
             .map(this.prefixClass.bind(this));
     };
     OpToHtmlConverter.prototype.getCssStyles = function () {
+        var STYLE_MAP = {
+            font: {
+                'serif': 'font-family: Georgia, Times New Roman, serif',
+                'monospace': 'font-family: Monaco, Courier New, monospace'
+            },
+            size: {
+                'small': 'font-size: 0.75em',
+                'large': 'font-size: 1.5em',
+                'huge': 'font-size: 2.5em'
+            }
+        };
         var attrs = this.op.attributes;
-        var propsArr = [['color']];
-        if (!this.options.allowBackgroundClasses) {
-            propsArr.push(['background', 'background-color']);
+        var propsArr = [{ attr: 'color', style: 'color' }];
+        if (!this.options.allowBackgroundClasses || this.options.inlineStyles) {
+            propsArr.push({ attr: 'background', style: 'background-color' });
+        }
+        if (this.options.inlineStyles) {
+            propsArr = propsArr.concat([
+                {
+                    attr: 'indent',
+                    style: function (value) {
+                        var indentSize = parseInt(value, 10) * 3;
+                        var side = attrs['direction'] === 'rtl' ? 'right' : 'left';
+                        return 'padding-' + side + ':' + indentSize + 'em';
+                    }
+                },
+                {
+                    attr: 'align',
+                    style: 'text-align'
+                },
+                {
+                    attr: 'direction',
+                    style: function (value) {
+                        if (value === 'rtl') {
+                            return 'direction:rtl' + (attrs['align'] ? '' : '; text-align: inherit');
+                        }
+                        else {
+                            return '';
+                        }
+                    }
+                },
+                {
+                    attr: 'font',
+                    style: function (value) { return STYLE_MAP.font[value] || ('font-family:' + value); }
+                },
+                {
+                    attr: 'size',
+                    style: function (value) { return STYLE_MAP.size[value] || ''; }
+                }
+            ]);
         }
         return propsArr
-            .filter(function (item) { return !!attrs[item[0]]; })
-            .map(function (item) { return arr.preferSecond(item) + ':' + attrs[item[0]]; });
+            .filter(function (item) { return !!attrs[item.attr]; })
+            .map(function (item) {
+            if (typeof (item.style) === 'string') {
+                return item.style + ':' + attrs[item.attr];
+            }
+            else {
+                return item.style(attrs[item.attr]);
+            }
+        });
     };
     OpToHtmlConverter.prototype.getTagAttributes = function () {
         if (this.op.attributes.code && !this.op.isLink()) {
@@ -417,9 +474,6 @@ var OpToHtmlConverter = (function () {
         }
         if (this.op.isACheckList()) {
             return tagAttrs.concat(makeAttr('data-checked', this.op.isCheckedList() ? 'true' : 'false'));
-        }
-        if (this.op.isFormula() || this.op.isContainerBlock()) {
-            return tagAttrs;
         }
         if (this.op.isVideo()) {
             return tagAttrs.concat(makeAttr('frameborder', '0'), makeAttr('allowfullscreen', 'true'), makeAttr('src', url.sanitize(this.op.insert.value + '') + ''));
@@ -440,9 +494,16 @@ var OpToHtmlConverter = (function () {
             }
             return tagAttrs;
         }
+        if (this.op.isFormula()) {
+            return tagAttrs;
+        }
         var styles = this.getCssStyles();
-        var styleAttr = styles.length ? [makeAttr('style', styles.join(';'))] : [];
-        tagAttrs = tagAttrs.concat(styleAttr);
+        if (styles.length) {
+            tagAttrs.push(makeAttr('style', styles.join(';')));
+        }
+        if (this.op.isContainerBlock()) {
+            return tagAttrs;
+        }
         if (this.op.isLink()) {
             var target = this.op.attributes.target || this.options.linkTarget;
             tagAttrs = tagAttrs
@@ -511,6 +572,7 @@ var QuillDeltaToHtmlConverter = (function () {
             paragraphTag: 'p',
             encodeHtml: true,
             classPrefix: 'ql',
+            inlineStyles: false,
             multiLineBlockquote: true,
             multiLineHeader: true,
             multiLineCodeblock: true,
@@ -525,6 +587,7 @@ var QuillDeltaToHtmlConverter = (function () {
         this.converterOptions = {
             encodeHtml: this.options.encodeHtml,
             classPrefix: this.options.classPrefix,
+            inlineStyles: this.options.inlineStyles,
             listItemTag: this.options.listItemTag,
             paragraphTag: this.options.paragraphTag,
             linkRel: this.options.linkRel,

--- a/dist/commonjs/OpToHtmlConverter.d.ts
+++ b/dist/commonjs/OpToHtmlConverter.d.ts
@@ -2,6 +2,7 @@ import { ITagKeyValue } from './funcs-html';
 import { DeltaInsertOp } from './DeltaInsertOp';
 interface IOpToHtmlConverterOptions {
     classPrefix?: string;
+    inlineStyles?: boolean;
     encodeHtml?: boolean;
     listItemTag?: string;
     paragraphTag?: string;

--- a/dist/commonjs/QuillDeltaToHtmlConverter.d.ts
+++ b/dist/commonjs/QuillDeltaToHtmlConverter.d.ts
@@ -7,6 +7,7 @@ interface IQuillDeltaToHtmlConverterOptions {
     listItemTag?: string;
     paragraphTag?: string;
     classPrefix?: string;
+    inlineStyles?: boolean;
     encodeHtml?: boolean;
     multiLineBlockquote?: boolean;
     multiLineHeader?: boolean;

--- a/dist/commonjs/QuillDeltaToHtmlConverter.js
+++ b/dist/commonjs/QuillDeltaToHtmlConverter.js
@@ -17,6 +17,7 @@ var QuillDeltaToHtmlConverter = (function () {
             paragraphTag: 'p',
             encodeHtml: true,
             classPrefix: 'ql',
+            inlineStyles: false,
             multiLineBlockquote: true,
             multiLineHeader: true,
             multiLineCodeblock: true,
@@ -31,6 +32,7 @@ var QuillDeltaToHtmlConverter = (function () {
         this.converterOptions = {
             encodeHtml: this.options.encodeHtml,
             classPrefix: this.options.classPrefix,
+            inlineStyles: this.options.inlineStyles,
             listItemTag: this.options.listItemTag,
             paragraphTag: this.options.paragraphTag,
             linkRel: this.options.linkRel,

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -1,6 +1,6 @@
 
 import { InsertOpsConverter } from './InsertOpsConverter';
-import { OpToHtmlConverter, IOpToHtmlConverterOptions } from './OpToHtmlConverter';
+import { OpToHtmlConverter, IOpToHtmlConverterOptions, IInlineStyles } from './OpToHtmlConverter';
 import { DeltaInsertOp } from './DeltaInsertOp';
 import { Grouper } from './grouper/Grouper';
 import {
@@ -20,7 +20,7 @@ interface IQuillDeltaToHtmlConverterOptions {
 
    paragraphTag?: string,
    classPrefix?: string,
-   inlineStyles?: boolean,
+   inlineStyles?: boolean | IInlineStyles,
    encodeHtml?: boolean,
    multiLineBlockquote?: boolean,
    multiLineHeader?: boolean,
@@ -64,10 +64,19 @@ class QuillDeltaToHtmlConverter {
             listItemTag: 'li'
          });
 
+      var inlineStyles : IInlineStyles | undefined;
+      if(this.options.inlineStyles === true) {
+         inlineStyles = {};
+      } else if(!this.options.inlineStyles) {
+         inlineStyles = undefined;
+      } else {
+         inlineStyles = this.options.inlineStyles;
+      }
+
       this.converterOptions = {
          encodeHtml: this.options.encodeHtml,
          classPrefix: this.options.classPrefix,
-         inlineStyles: this.options.inlineStyles,
+         inlineStyles: inlineStyles,
          listItemTag: this.options.listItemTag,
          paragraphTag: this.options.paragraphTag,
          linkRel: this.options.linkRel,

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -20,6 +20,7 @@ interface IQuillDeltaToHtmlConverterOptions {
 
    paragraphTag?: string,
    classPrefix?: string,
+   inlineStyles?: boolean,
    encodeHtml?: boolean,
    multiLineBlockquote?: boolean,
    multiLineHeader?: boolean,
@@ -50,6 +51,7 @@ class QuillDeltaToHtmlConverter {
          paragraphTag: 'p',
          encodeHtml: true,
          classPrefix: 'ql',
+         inlineStyles: false,
          multiLineBlockquote: true,
          multiLineHeader: true,
          multiLineCodeblock: true,
@@ -65,6 +67,7 @@ class QuillDeltaToHtmlConverter {
       this.converterOptions = {
          encodeHtml: this.options.encodeHtml,
          classPrefix: this.options.classPrefix,
+         inlineStyles: this.options.inlineStyles,
          listItemTag: this.options.listItemTag,
          paragraphTag: this.options.paragraphTag,
          linkRel: this.options.linkRel,
@@ -85,7 +88,7 @@ class QuillDeltaToHtmlConverter {
 
    getGroupedOps(): TDataGroup[] {
       var deltaOps = InsertOpsConverter.convert(this.rawDeltaOps);
-      
+
       var pairedOps = Grouper.pairOpsWithTheirBlock(deltaOps);
 
       var groupedSameStyleBlocks = Grouper.groupConsecutiveSameStyleBlocks(pairedOps, {
@@ -113,7 +116,7 @@ class QuillDeltaToHtmlConverter {
 
             return this._renderWithCallbacks(
                GroupType.Block, group, () => this._renderBlock(g.op, g.ops));
-         
+
          } else if (group instanceof BlotBlock) {
 
             return this._renderCustom(group.op, null);

--- a/test/OpToHtmlConverter.test.ts
+++ b/test/OpToHtmlConverter.test.ts
@@ -54,6 +54,44 @@ describe('OpToHtmlConverter', function () {
             assert.deepEqual(c.getCssStyles(), ['color:blue']);
 
         });
+
+        it('should return inline styles', () => {
+            var op = new DeltaInsertOp("hello");
+            var c = new OpToHtmlConverter(op, { inlineStyles: true });
+            assert.deepEqual(c.getCssStyles(), []);
+
+            var attrs = {
+                indent: 1, align: AlignType.Center, direction: DirectionType.Rtl,
+                font: 'roman', size: 'small', background: 'red'
+            }
+            var o = new DeltaInsertOp('f', attrs);
+            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            var styles = [
+                'background-color:red',
+                'padding-right:3em',
+                'text-align:center',
+                'direction:rtl',
+                'font-family:roman',
+                'font-size: 0.75em'
+            ];
+            assert.deepEqual(c.getCssStyles(), styles);
+
+            o = new DeltaInsertOp(new InsertDataQuill(DataType.Image, ""), attrs);
+            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            assert.deepEqual(c.getCssStyles(), styles);
+
+            o = new DeltaInsertOp(new InsertDataQuill(DataType.Video, ""), attrs);
+            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            assert.deepEqual(c.getCssStyles(), styles);
+
+            o = new DeltaInsertOp(new InsertDataQuill(DataType.Formula, ""), attrs);
+            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            assert.deepEqual(c.getCssStyles(), styles);
+
+            o = new DeltaInsertOp('f', attrs);
+            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            assert.deepEqual(c.getCssStyles(), styles);
+        });
     });
 
     describe('getCssClasses()', function () {

--- a/test/OpToHtmlConverter.test.ts
+++ b/test/OpToHtmlConverter.test.ts
@@ -57,7 +57,7 @@ describe('OpToHtmlConverter', function () {
 
         it('should return inline styles', () => {
             var op = new DeltaInsertOp("hello");
-            var c = new OpToHtmlConverter(op, { inlineStyles: true });
+            var c = new OpToHtmlConverter(op, { inlineStyles: {} });
             assert.deepEqual(c.getCssStyles(), []);
 
             var attrs = {
@@ -65,7 +65,7 @@ describe('OpToHtmlConverter', function () {
                 font: 'roman', size: 'small', background: 'red'
             }
             var o = new DeltaInsertOp('f', attrs);
-            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            c = new OpToHtmlConverter(o, { inlineStyles: {} });
             var styles = [
                 'background-color:red',
                 'padding-right:3em',
@@ -77,19 +77,19 @@ describe('OpToHtmlConverter', function () {
             assert.deepEqual(c.getCssStyles(), styles);
 
             o = new DeltaInsertOp(new InsertDataQuill(DataType.Image, ""), attrs);
-            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            c = new OpToHtmlConverter(o, { inlineStyles: {} });
             assert.deepEqual(c.getCssStyles(), styles);
 
             o = new DeltaInsertOp(new InsertDataQuill(DataType.Video, ""), attrs);
-            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            c = new OpToHtmlConverter(o, { inlineStyles: {} });
             assert.deepEqual(c.getCssStyles(), styles);
 
             o = new DeltaInsertOp(new InsertDataQuill(DataType.Formula, ""), attrs);
-            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            c = new OpToHtmlConverter(o, { inlineStyles: {} });
             assert.deepEqual(c.getCssStyles(), styles);
 
             o = new DeltaInsertOp('f', attrs);
-            c = new OpToHtmlConverter(o, { inlineStyles: true });
+            c = new OpToHtmlConverter(o, { inlineStyles: {} });
             assert.deepEqual(c.getCssStyles(), styles);
         });
     });


### PR DESCRIPTION
If `inlineStyles` option is supplied, then instead of adding classes to each element, styles will be
added inline.  This is handy for supporting rending a quill delta to an email.  This also provides a way to customize how inline styles are rendered.

See #46.