### PR TITLE
Allow RGB format for color attributes

### DIFF
--- a/dist/browser/QuillDeltaToHtmlConverter.bundle.js
+++ b/dist/browser/QuillDeltaToHtmlConverter.bundle.js
@@ -244,7 +244,8 @@ var OpAttributeSanitizer = (function () {
         colorAttrs.forEach(function (prop) {
             var val = dirtyAttrs[prop];
             if (val && (OpAttributeSanitizer.IsValidHexColor(val + '') ||
-                OpAttributeSanitizer.IsValidColorLiteral(val + ''))) {
+                OpAttributeSanitizer.IsValidColorLiteral(val + '') ||
+                OpAttributeSanitizer.IsValidRGBColor(val + ''))) {
                 cleanAttrs[prop] = val;
             }
         });
@@ -301,6 +302,10 @@ var OpAttributeSanitizer = (function () {
     };
     OpAttributeSanitizer.IsValidColorLiteral = function (colorStr) {
         return !!colorStr.match(/^[a-z]{1,50}$/i);
+    };
+    OpAttributeSanitizer.IsValidRGBColor = function (colorStr) {
+        var re = /^rgb\(((0|25[0-5]|2[0-4]\d|1\d\d|0?\d?\d),\s*){2}(0|25[0-5]|2[0-4]\d|1\d\d|0?\d?\d)\)$/i;
+        return !!colorStr.match(re);
     };
     OpAttributeSanitizer.IsValidFontName = function (fontName) {
         return !!fontName.match(/^[a-z\s0-9\- ]{1,30}$/i);
@@ -584,14 +589,14 @@ var QuillDeltaToHtmlConverter = (function () {
             listItemTag: 'li'
         });
         var inlineStyles;
-        if (this.options.inlineStyles === true) {
-            inlineStyles = {};
-        }
-        else if (!this.options.inlineStyles) {
+        if (!this.options.inlineStyles) {
             inlineStyles = undefined;
         }
-        else {
+        else if (typeof (this.options.inlineStyles) === 'object') {
             inlineStyles = this.options.inlineStyles;
+        }
+        else {
+            inlineStyles = {};
         }
         this.converterOptions = {
             encodeHtml: this.options.encodeHtml,

--- a/dist/commonjs/OpAttributeSanitizer.d.ts
+++ b/dist/commonjs/OpAttributeSanitizer.d.ts
@@ -29,6 +29,7 @@ declare class OpAttributeSanitizer {
     static sanitize(dirtyAttrs: IOpAttributes): IOpAttributes;
     static IsValidHexColor(colorStr: string): boolean;
     static IsValidColorLiteral(colorStr: string): boolean;
+    static IsValidRGBColor(colorStr: string): boolean;
     static IsValidFontName(fontName: string): boolean;
     static IsValidSize(size: string): boolean;
     static IsValidWidth(width: string): boolean;

--- a/dist/commonjs/OpAttributeSanitizer.js
+++ b/dist/commonjs/OpAttributeSanitizer.js
@@ -28,7 +28,8 @@ var OpAttributeSanitizer = (function () {
         colorAttrs.forEach(function (prop) {
             var val = dirtyAttrs[prop];
             if (val && (OpAttributeSanitizer.IsValidHexColor(val + '') ||
-                OpAttributeSanitizer.IsValidColorLiteral(val + ''))) {
+                OpAttributeSanitizer.IsValidColorLiteral(val + '') ||
+                OpAttributeSanitizer.IsValidRGBColor(val + ''))) {
                 cleanAttrs[prop] = val;
             }
         });
@@ -85,6 +86,10 @@ var OpAttributeSanitizer = (function () {
     };
     OpAttributeSanitizer.IsValidColorLiteral = function (colorStr) {
         return !!colorStr.match(/^[a-z]{1,50}$/i);
+    };
+    OpAttributeSanitizer.IsValidRGBColor = function (colorStr) {
+        var re = /^rgb\(((0|25[0-5]|2[0-4]\d|1\d\d|0?\d?\d),\s*){2}(0|25[0-5]|2[0-4]\d|1\d\d|0?\d?\d)\)$/i;
+        return !!colorStr.match(re);
     };
     OpAttributeSanitizer.IsValidFontName = function (fontName) {
         return !!fontName.match(/^[a-z\s0-9\- ]{1,30}$/i);

--- a/src/OpAttributeSanitizer.ts
+++ b/src/OpAttributeSanitizer.ts
@@ -70,7 +70,8 @@ class OpAttributeSanitizer {
       colorAttrs.forEach(function (prop: string) {
          var val = (<any>dirtyAttrs)[prop];
          if (val && (OpAttributeSanitizer.IsValidHexColor(val + '') ||
-            OpAttributeSanitizer.IsValidColorLiteral(val + ''))) {
+            OpAttributeSanitizer.IsValidColorLiteral(val + '') ||
+            OpAttributeSanitizer.IsValidRGBColor(val + ''))) {
             cleanAttrs[prop] = val;
          }
       });
@@ -140,6 +141,11 @@ class OpAttributeSanitizer {
 
    static IsValidColorLiteral(colorStr: string) {
       return !!colorStr.match(/^[a-z]{1,50}$/i);
+   }
+
+   static IsValidRGBColor(colorStr: string) {
+       const re = /^rgb\(((0|25[0-5]|2[0-4]\d|1\d\d|0?\d?\d),\s*){2}(0|25[0-5]|2[0-4]\d|1\d\d|0?\d?\d)\)$/i
+       return !!colorStr.match(re);
    }
 
    static IsValidFontName(fontName: string) {

--- a/test/OpAttributeSanitizer.test.ts
+++ b/test/OpAttributeSanitizer.test.ts
@@ -58,6 +58,19 @@ describe('OpAttributeSanitizer', function () {
         });
     });
 
+    describe('#IsValidRGBColor()', function() {
+        it('should return true if rgb color is valid', function() {
+            assert.ok(OpAttributeSanitizer.IsValidRGBColor('rgb(0,0,0)'));
+            assert.ok(OpAttributeSanitizer.IsValidRGBColor('rgb(255, 99, 1)'));
+            assert.ok(OpAttributeSanitizer.IsValidRGBColor('RGB(254, 249, 109)'));
+            assert.equal(OpAttributeSanitizer.IsValidRGBColor('yellow'), false);
+            assert.equal(OpAttributeSanitizer.IsValidRGBColor('#FFF'), false);
+            assert.equal(OpAttributeSanitizer.IsValidRGBColor('rgb(256,0,0)'), false);
+            assert.equal(OpAttributeSanitizer.IsValidRGBColor('rgb(260,0,0)'), false);
+            assert.equal(OpAttributeSanitizer.IsValidRGBColor('rgb(2000,0,0)'), false);
+        });
+    });
+
     describe('#sanitize()', function() {
 
         it('should return empty object', function() {


### PR DESCRIPTION
Fixes: #49 

A rudimentary check to accept color attributes in RGB format. It doesn't check for RGBA or HSL formats, nor percentage-based values, which technically are also valid. So another option is a more loose, forgiving regex that is less accurate.  