### PR TITLE
Add ability to supply custom encoding mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,19 @@ var html = converter.convert();
 
 |Option | Default | Description 
 |---|---|---|
-|paragraphTag| 'p' | Custom tag to wrap inline html elements|
-|encodeHtml| true | If true, `<, >, /, ', ", &` characters in content will be encoded.|
-|classPrefix| 'ql' | A css class name to prefix class generating styles such as `size`, `font`, etc. |
-|inlineStyles| false | If true, use inline styles instead of classes |
-|multiLineBlockquote| true | Instead of rendering multiple `blockquote` elements for quotes that are consecutive and have same styles(`align`, `indent`, and `direction`), it renders them into only one|
-|multiLineHeader| true | Same deal as `multiLineBlockquote` for headers|
-|multiLineCodeblock| true | Same deal as `multiLineBlockquote` for code-blocks|
-|multiLineParagraph| true | Set to false to generate a new paragraph tag after each enter press (new line)|
-|linkRel| '' | Specifies a value to put on the `rel` attr on links|
-|linkTarget| '_blank' | Specifies target for all links; use `''` (empty string) to not generate `target` attribute. This can be overridden by an individual link op by specifiying the `target` with a value in the respective op's attributes.|
-|allowBackgroundClasses| false | If true, css classes will be added for background attr|
+|`paragraphTag`| 'p' | Custom tag to wrap inline html elements|
+|`encodeHtml`| true | If true, `<, >, /, ', ", &` characters in content will be encoded.|
+|`classPrefix`| 'ql' | A css class name to prefix class generating styles such as `size`, `font`, etc. |
+|`inlineStyles`| false | If true, use inline styles instead of classes |
+|`multiLineBlockquote`| true | Instead of rendering multiple `blockquote` elements for quotes that are consecutive and have same styles(`align`, `indent`, and `direction`), it renders them into only one|
+|`multiLineHeader`| true | Same deal as `multiLineBlockquote` for headers|
+|`multiLineCodeblock`| true | Same deal as `multiLineBlockquote` for code-blocks|
+|`multiLineParagraph`| true | Set to false to generate a new paragraph tag after each enter press (new line)|
+|`linkRel`| '' | Specifies a value to put on the `rel` attr on links|
+|`linkTarget`| '_blank' | Specifies target for all links; use `''` (empty string) to not generate `target` attribute. This can be overridden by an individual link op by specifying the `target` with a value in the respective op's attributes.|
+|`allowBackgroundClasses`| false | If true, css classes will be added for background attr|
+|`urlWhiteListExtensions`| undefined | Array of strings that if matched a url beginning with that string will ne be escaped
+| `encodeMapExtensions` | undefined | Array of encode map extensions see Advanced Custom encoding docs below for more
 
 ## Rendering Quill Formats ##
 
@@ -185,6 +187,44 @@ html = converter.convert();
         // ... any attributes custom blot may have
     }
 }
+```
+
+## Advanced Custom encoding ##
+Supplying the option `encodeMapExtensions` as an array of `EncodeMapExtension` objects represented by the interface:
+```ts
+interface IEncodeMapExtension {
+    key: string, 
+    url: boolean, 
+    html: boolean, 
+    encodeTo: string, 
+    encodeMatch: string, 
+    decodeTo: string, 
+    decodeMatch: string
+}
+```
+
+| Option | Description 
+|---|---|
+| `key` | An indicator that will give this extension uniqueness any collisions will result in 'last in' being used|
+| `url` | If true will be used in url encoding|
+| `html` | If true will be used in html encoding|
+| `encodeTo` | What to encode the `decodeTo` value to when a `decodeMatch` is hit|
+| `encodeMatch` | Pattern of encoded value |
+| `decodeTo` | What to decode the `encodedTo` value to when a `encodeMatch` is hit |
+| `decodeMatch` | Pattern of decoded value |
+
+### Example
+Encodes `(` to `&#40;` for urls only
+```ts
+[{
+    key: '(',
+    url: true,
+    html: false,
+    encodeTo: '&#40;',
+    encodeMatch: '&#40;',
+    decodeTo: '(',
+    decodeMatch: '\\('
+}]
 ```
 
 ## Advanced Custom Rendering Using Grouped Ops ##

--- a/dist/browser/QuillDeltaToHtmlConverter.bundle.js
+++ b/dist/browser/QuillDeltaToHtmlConverter.bundle.js
@@ -804,31 +804,89 @@ function encodeLink(str) {
 exports.encodeLink = encodeLink;
 function encodeMappings(mtype) {
     var maps = [
-        ['&', '&amp;'],
-        ['"', '&quot;'],
-        ["'", "&#x27;"],
-        ['\\/', '&#x2F;'],
-        ['\\(', '&#40;'],
-        ['\\)', '&#41;']
+        {
+            url: true,
+            html: true,
+            encodeTo: '&amp;',
+            encodeMatch: '&amp;',
+            decodeTo: '&',
+            decodeMatch: '&'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '&lt;$1',
+            encodeMatch: '&lt;',
+            decodeTo: '<',
+            decodeMatch: '<([^%])'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '$1&gt;',
+            encodeMatch: '&gt;',
+            decodeTo: '>',
+            decodeMatch: '([^%])>'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '&quot;',
+            encodeMatch: '&quot;',
+            decodeTo: '"',
+            decodeMatch: '"'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '&#x27;',
+            encodeMatch: '&#x27;',
+            decodeTo: "'",
+            decodeMatch: "'"
+        },
+        {
+            url: false,
+            html: true,
+            encodeTo: '&#x2F;',
+            encodeMatch: '&#x2F;',
+            decodeTo: '/',
+            decodeMatch: '/'
+        },
+        {
+            url: true,
+            html: false,
+            encodeTo: '&#40;',
+            encodeMatch: '&#40;',
+            decodeTo: '(',
+            decodeMatch: '\\('
+        },
+        {
+            url: true,
+            html: false,
+            encodeTo: '&#41;',
+            encodeMatch: '&#41;',
+            decodeTo: ')',
+            decodeMatch: '\\)'
+        }
     ];
     if (mtype === EncodeTarget.Html) {
         return maps.filter(function (_a) {
-            var v = _a[0], _ = _a[1];
-            return v.indexOf('(') === -1 && v.indexOf(')') === -1;
+            var html = _a.html;
+            return html;
         });
     }
     else {
         return maps.filter(function (_a) {
-            var v = _a[0], _ = _a[1];
-            return v.indexOf('/') === -1;
+            var url = _a.url;
+            return url;
         });
     }
 }
 function encodeMapping(str, mapping) {
-    return str.replace(new RegExp(mapping[0], 'g'), mapping[1]);
+    return str.replace(new RegExp(mapping.decodeMatch, 'g'), mapping.encodeTo);
 }
 function decodeMapping(str, mapping) {
-    return str.replace(new RegExp(mapping[1], 'g'), mapping[0].replace('\\', ''));
+    return str.replace(new RegExp(mapping.encodeMatch, 'g'), mapping.decodeTo);
 }
 
 },{}],9:[function(require,module,exports){

--- a/dist/browser/QuillDeltaToHtmlConverter.bundle.js
+++ b/dist/browser/QuillDeltaToHtmlConverter.bundle.js
@@ -805,8 +805,6 @@ exports.encodeLink = encodeLink;
 function encodeMappings(mtype) {
     var maps = [
         ['&', '&amp;'],
-        ['<', '&lt;'],
-        ['>', '&gt;'],
         ['"', '&quot;'],
         ["'", "&#x27;"],
         ['\\/', '&#x2F;'],
@@ -1211,7 +1209,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 function sanitize(str) {
     var val = str;
     val = val.replace(/^\s*/gm, '');
-    var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|#|\/|data:image\/)/;
+    var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|<%|#|\/|data:image\/)/;
     if (whiteList.test(val)) {
         return val;
     }

--- a/dist/commonjs/InsertOpsConverter.d.ts
+++ b/dist/commonjs/InsertOpsConverter.d.ts
@@ -1,7 +1,7 @@
 import { DeltaInsertOp } from './DeltaInsertOp';
 import { InsertData } from './InsertData';
 declare class InsertOpsConverter {
-    static convert(deltaOps: null | any[]): DeltaInsertOp[];
+    static convert(deltaOps: null | any[], urlWhiteListExtensions?: string[]): DeltaInsertOp[];
     static convertInsertVal(insertPropVal: any): InsertData | null;
 }
 export { InsertOpsConverter };

--- a/dist/commonjs/InsertOpsConverter.js
+++ b/dist/commonjs/InsertOpsConverter.js
@@ -8,7 +8,7 @@ var InsertOpDenormalizer_1 = require("./InsertOpDenormalizer");
 var InsertOpsConverter = (function () {
     function InsertOpsConverter() {
     }
-    InsertOpsConverter.convert = function (deltaOps) {
+    InsertOpsConverter.convert = function (deltaOps, urlWhiteListExtensions) {
         if (!Array.isArray(deltaOps)) {
             return [];
         }
@@ -24,7 +24,7 @@ var InsertOpsConverter = (function () {
             if (!insertVal) {
                 continue;
             }
-            attributes = OpAttributeSanitizer_1.OpAttributeSanitizer.sanitize(op.attributes);
+            attributes = OpAttributeSanitizer_1.OpAttributeSanitizer.sanitize(op.attributes, urlWhiteListExtensions);
             results.push(new DeltaInsertOp_1.DeltaInsertOp(insertVal, attributes));
         }
         return results;

--- a/dist/commonjs/OpAttributeSanitizer.d.ts
+++ b/dist/commonjs/OpAttributeSanitizer.d.ts
@@ -26,7 +26,7 @@ interface IOpAttributes {
     renderAsBlock?: boolean | undefined;
 }
 declare class OpAttributeSanitizer {
-    static sanitize(dirtyAttrs: IOpAttributes): IOpAttributes;
+    static sanitize(dirtyAttrs: IOpAttributes, urlWhiteListExtensions?: string[]): IOpAttributes;
     static IsValidHexColor(colorStr: string): boolean;
     static IsValidColorLiteral(colorStr: string): boolean;
     static IsValidRGBColor(colorStr: string): boolean;

--- a/dist/commonjs/OpAttributeSanitizer.js
+++ b/dist/commonjs/OpAttributeSanitizer.js
@@ -6,7 +6,7 @@ var url = require("./helpers/url");
 var OpAttributeSanitizer = (function () {
     function OpAttributeSanitizer() {
     }
-    OpAttributeSanitizer.sanitize = function (dirtyAttrs) {
+    OpAttributeSanitizer.sanitize = function (dirtyAttrs, urlWhiteListExtensions) {
         var cleanAttrs = {};
         if (!dirtyAttrs || typeof dirtyAttrs !== 'object') {
             return cleanAttrs;
@@ -43,7 +43,7 @@ var OpAttributeSanitizer = (function () {
             cleanAttrs.width = width;
         }
         if (link) {
-            cleanAttrs.link = url.sanitize(link + '');
+            cleanAttrs.link = url.sanitize(link + '', urlWhiteListExtensions);
         }
         if (target && OpAttributeSanitizer.isValidTarget(target)) {
             cleanAttrs.target = target;
@@ -67,7 +67,7 @@ var OpAttributeSanitizer = (function () {
             cleanAttrs.indent = Math.min(Number(indent), 30);
         }
         if (mentions && mention) {
-            var sanitizedMention = MentionSanitizer_1.MentionSanitizer.sanitize(mention);
+            var sanitizedMention = MentionSanitizer_1.MentionSanitizer.sanitize(mention, urlWhiteListExtensions);
             if (Object.keys(sanitizedMention).length > 0) {
                 cleanAttrs.mentions = !!mentions;
                 cleanAttrs.mention = mention;

--- a/dist/commonjs/OpToHtmlConverter.d.ts
+++ b/dist/commonjs/OpToHtmlConverter.d.ts
@@ -1,4 +1,4 @@
-import { ITagKeyValue } from './funcs-html';
+import { ITagKeyValue, IEncodeMapExtension } from './funcs-html';
 import { DeltaInsertOp } from './DeltaInsertOp';
 export declare type InlineStyleType = ((value: string, op: DeltaInsertOp) => string | undefined) | {
     [x: string]: string;
@@ -20,15 +20,7 @@ interface IOpToHtmlConverterOptions {
     linkRel?: string;
     linkTarget?: string;
     allowBackgroundClasses?: boolean;
-    encodeMapExtensions?: {
-        key: string;
-        url: boolean;
-        html: boolean;
-        encodeTo: string;
-        encodeMatch: string;
-        decodeTo: string;
-        decodeMatch: string;
-    }[];
+    encodeMapExtensions?: IEncodeMapExtension[];
     urlWhiteListExtensions?: string[];
 }
 interface IHtmlParts {

--- a/dist/commonjs/OpToHtmlConverter.d.ts
+++ b/dist/commonjs/OpToHtmlConverter.d.ts
@@ -20,6 +20,15 @@ interface IOpToHtmlConverterOptions {
     linkRel?: string;
     linkTarget?: string;
     allowBackgroundClasses?: boolean;
+    encodeMapExtensions?: {
+        key: string;
+        url: boolean;
+        html: boolean;
+        encodeTo: string;
+        encodeMatch: string;
+        decodeTo: string;
+        decodeMatch: string;
+    }[];
 }
 interface IHtmlParts {
     openingTag: string;

--- a/dist/commonjs/OpToHtmlConverter.d.ts
+++ b/dist/commonjs/OpToHtmlConverter.d.ts
@@ -29,6 +29,7 @@ interface IOpToHtmlConverterOptions {
         decodeTo: string;
         decodeMatch: string;
     }[];
+    urlWhiteListExtensions?: string[];
 }
 interface IHtmlParts {
     openingTag: string;

--- a/dist/commonjs/OpToHtmlConverter.js
+++ b/dist/commonjs/OpToHtmlConverter.js
@@ -83,7 +83,7 @@ var OpToHtmlConverter = (function () {
             return this.op.insert.value;
         }
         var content = this.op.isFormula() || this.op.isText() ? this.op.insert.value : '';
-        return this.options.encodeHtml && funcs_html_1.encodeHtml(content) || content;
+        return this.options.encodeHtml && funcs_html_1.encodeHtml(content, undefined, this.options.encodeMapExtensions) || content;
     };
     OpToHtmlConverter.prototype.getCssClasses = function () {
         var attrs = this.op.attributes;
@@ -165,7 +165,7 @@ var OpToHtmlConverter = (function () {
                 tagAttrs = tagAttrs.concat(makeAttr('class', mention.class));
             }
             if (mention['end-point'] && mention.slug) {
-                tagAttrs = tagAttrs.concat(makeAttr('href', funcs_html_1.encodeLink(mention['end-point'] + '/' + mention.slug)));
+                tagAttrs = tagAttrs.concat(makeAttr('href', funcs_html_1.encodeLink(mention['end-point'] + '/' + mention.slug, this.options.encodeMapExtensions)));
             }
             else {
                 tagAttrs = tagAttrs.concat(makeAttr('href', 'about:blank'));
@@ -185,7 +185,7 @@ var OpToHtmlConverter = (function () {
         if (this.op.isLink()) {
             var target = this.op.attributes.target || this.options.linkTarget;
             tagAttrs = tagAttrs
-                .concat(makeAttr('href', funcs_html_1.encodeLink(this.op.attributes.link)))
+                .concat(makeAttr('href', funcs_html_1.encodeLink(this.op.attributes.link, this.options.encodeMapExtensions)))
                 .concat(target ? makeAttr('target', target) : []);
             if (!!this.options.linkRel && OpToHtmlConverter.IsValidRel(this.options.linkRel)) {
                 tagAttrs.push(makeAttr('rel', this.options.linkRel));

--- a/dist/commonjs/OpToHtmlConverter.js
+++ b/dist/commonjs/OpToHtmlConverter.js
@@ -148,7 +148,7 @@ var OpToHtmlConverter = (function () {
         var tagAttrs = classes.length ? [makeAttr('class', classes.join(' '))] : [];
         if (this.op.isImage()) {
             this.op.attributes.width && (tagAttrs = tagAttrs.concat(makeAttr('width', this.op.attributes.width)));
-            return tagAttrs.concat(makeAttr('src', url.sanitize(this.op.insert.value + '') + ''));
+            return tagAttrs.concat(makeAttr('src', url.sanitize(this.op.insert.value + '', this.options.urlWhiteListExtensions) + ''));
         }
         if (this.op.isACheckList()) {
             return tagAttrs.concat(makeAttr('data-checked', this.op.isCheckedList() ? 'true' : 'false'));
@@ -157,7 +157,7 @@ var OpToHtmlConverter = (function () {
             return tagAttrs;
         }
         if (this.op.isVideo()) {
-            return tagAttrs.concat(makeAttr('frameborder', '0'), makeAttr('allowfullscreen', 'true'), makeAttr('src', url.sanitize(this.op.insert.value + '') + ''));
+            return tagAttrs.concat(makeAttr('frameborder', '0'), makeAttr('allowfullscreen', 'true'), makeAttr('src', url.sanitize(this.op.insert.value + '', this.options.urlWhiteListExtensions) + ''));
         }
         if (this.op.isMentions()) {
             var mention = this.op.attributes.mention;

--- a/dist/commonjs/QuillDeltaToHtmlConverter.d.ts
+++ b/dist/commonjs/QuillDeltaToHtmlConverter.d.ts
@@ -17,6 +17,15 @@ interface IQuillDeltaToHtmlConverterOptions {
     linkRel?: string;
     linkTarget?: string;
     allowBackgroundClasses?: boolean;
+    encodeMapExtensions?: {
+        key: string;
+        url: boolean;
+        html: boolean;
+        encodeTo: string;
+        encodeMatch: string;
+        decodeTo: string;
+        decodeMatch: string;
+    }[];
 }
 declare class QuillDeltaToHtmlConverter {
     private options;

--- a/dist/commonjs/QuillDeltaToHtmlConverter.d.ts
+++ b/dist/commonjs/QuillDeltaToHtmlConverter.d.ts
@@ -26,6 +26,7 @@ interface IQuillDeltaToHtmlConverterOptions {
         decodeTo: string;
         decodeMatch: string;
     }[];
+    urlWhiteListExtensions?: string[];
 }
 declare class QuillDeltaToHtmlConverter {
     private options;

--- a/dist/commonjs/QuillDeltaToHtmlConverter.d.ts
+++ b/dist/commonjs/QuillDeltaToHtmlConverter.d.ts
@@ -1,6 +1,7 @@
 import { IInlineStyles } from './OpToHtmlConverter';
 import { DeltaInsertOp } from './DeltaInsertOp';
 import { ListGroup, ListItem, TDataGroup } from './grouper/group-types';
+import { IEncodeMapExtension } from './funcs-html';
 import { GroupType } from './value-types';
 interface IQuillDeltaToHtmlConverterOptions {
     orderedListTag?: string;
@@ -17,15 +18,7 @@ interface IQuillDeltaToHtmlConverterOptions {
     linkRel?: string;
     linkTarget?: string;
     allowBackgroundClasses?: boolean;
-    encodeMapExtensions?: {
-        key: string;
-        url: boolean;
-        html: boolean;
-        encodeTo: string;
-        encodeMatch: string;
-        decodeTo: string;
-        decodeMatch: string;
-    }[];
+    encodeMapExtensions?: IEncodeMapExtension[];
     urlWhiteListExtensions?: string[];
 }
 declare class QuillDeltaToHtmlConverter {

--- a/dist/commonjs/QuillDeltaToHtmlConverter.js
+++ b/dist/commonjs/QuillDeltaToHtmlConverter.js
@@ -47,7 +47,8 @@ var QuillDeltaToHtmlConverter = (function () {
             paragraphTag: this.options.paragraphTag,
             linkRel: this.options.linkRel,
             linkTarget: this.options.linkTarget,
-            allowBackgroundClasses: this.options.allowBackgroundClasses
+            allowBackgroundClasses: this.options.allowBackgroundClasses,
+            encodeMapExtensions: this.options.encodeMapExtensions
         };
         this.rawDeltaOps = deltaOps;
     }

--- a/dist/commonjs/QuillDeltaToHtmlConverter.js
+++ b/dist/commonjs/QuillDeltaToHtmlConverter.js
@@ -48,7 +48,8 @@ var QuillDeltaToHtmlConverter = (function () {
             linkRel: this.options.linkRel,
             linkTarget: this.options.linkTarget,
             allowBackgroundClasses: this.options.allowBackgroundClasses,
-            encodeMapExtensions: this.options.encodeMapExtensions
+            encodeMapExtensions: this.options.encodeMapExtensions,
+            urlWhiteListExtensions: this.options.urlWhiteListExtensions
         };
         this.rawDeltaOps = deltaOps;
     }
@@ -60,7 +61,7 @@ var QuillDeltaToHtmlConverter = (function () {
                         : '';
     };
     QuillDeltaToHtmlConverter.prototype.getGroupedOps = function () {
-        var deltaOps = InsertOpsConverter_1.InsertOpsConverter.convert(this.rawDeltaOps);
+        var deltaOps = InsertOpsConverter_1.InsertOpsConverter.convert(this.rawDeltaOps, this.options.urlWhiteListExtensions);
         var pairedOps = Grouper_1.Grouper.pairOpsWithTheirBlock(deltaOps);
         var groupedSameStyleBlocks = Grouper_1.Grouper.groupConsecutiveSameStyleBlocks(pairedOps, {
             blockquotes: !!this.options.multiLineBlockquote,

--- a/dist/commonjs/funcs-html.d.ts
+++ b/dist/commonjs/funcs-html.d.ts
@@ -2,33 +2,18 @@ interface ITagKeyValue {
     key: string;
     value?: string;
 }
+interface IEncodeMapExtension {
+    key: string;
+    url: boolean;
+    html: boolean;
+    encodeTo: string;
+    encodeMatch: string;
+    decodeTo: string;
+    decodeMatch: string;
+}
 declare function makeStartTag(tag: any, attrs?: ITagKeyValue | ITagKeyValue[] | undefined): string;
 declare function makeEndTag(tag?: any): string;
-declare function decodeHtml(str: string, encodeMapExtensions?: {
-    key: string;
-    url: boolean;
-    html: boolean;
-    encodeTo: string;
-    encodeMatch: string;
-    decodeTo: string;
-    decodeMatch: string;
-}[]): string;
-declare function encodeHtml(str: string, preventDoubleEncoding?: boolean, encodeMapExtensions?: {
-    key: string;
-    url: boolean;
-    html: boolean;
-    encodeTo: string;
-    encodeMatch: string;
-    decodeTo: string;
-    decodeMatch: string;
-}[]): string;
-declare function encodeLink(str: string, encodeMapExtensions?: {
-    key: string;
-    url: boolean;
-    html: boolean;
-    encodeTo: string;
-    encodeMatch: string;
-    decodeTo: string;
-    decodeMatch: string;
-}[]): string;
-export { makeStartTag, makeEndTag, encodeHtml, decodeHtml, encodeLink, ITagKeyValue };
+declare function decodeHtml(str: string, encodeMapExtensions?: IEncodeMapExtension[]): string;
+declare function encodeHtml(str: string, preventDoubleEncoding?: boolean, encodeMapExtensions?: IEncodeMapExtension[]): string;
+declare function encodeLink(str: string, encodeMapExtensions?: IEncodeMapExtension[]): string;
+export { makeStartTag, makeEndTag, encodeHtml, decodeHtml, encodeLink, ITagKeyValue, IEncodeMapExtension };

--- a/dist/commonjs/funcs-html.d.ts
+++ b/dist/commonjs/funcs-html.d.ts
@@ -4,7 +4,31 @@ interface ITagKeyValue {
 }
 declare function makeStartTag(tag: any, attrs?: ITagKeyValue | ITagKeyValue[] | undefined): string;
 declare function makeEndTag(tag?: any): string;
-declare function decodeHtml(str: string): string;
-declare function encodeHtml(str: string, preventDoubleEncoding?: boolean): string;
-declare function encodeLink(str: string): string;
+declare function decodeHtml(str: string, encodeMapExtensions?: {
+    key: string;
+    url: boolean;
+    html: boolean;
+    encodeTo: string;
+    encodeMatch: string;
+    decodeTo: string;
+    decodeMatch: string;
+}[]): string;
+declare function encodeHtml(str: string, preventDoubleEncoding?: boolean, encodeMapExtensions?: {
+    key: string;
+    url: boolean;
+    html: boolean;
+    encodeTo: string;
+    encodeMatch: string;
+    decodeTo: string;
+    decodeMatch: string;
+}[]): string;
+declare function encodeLink(str: string, encodeMapExtensions?: {
+    key: string;
+    url: boolean;
+    html: boolean;
+    encodeTo: string;
+    encodeMatch: string;
+    decodeTo: string;
+    decodeMatch: string;
+}[]): string;
 export { makeStartTag, makeEndTag, encodeHtml, decodeHtml, encodeLink, ITagKeyValue };

--- a/dist/commonjs/funcs-html.js
+++ b/dist/commonjs/funcs-html.js
@@ -50,8 +50,6 @@ exports.encodeLink = encodeLink;
 function encodeMappings(mtype) {
     var maps = [
         ['&', '&amp;'],
-        ['<', '&lt;'],
-        ['>', '&gt;'],
         ['"', '&quot;'],
         ["'", "&#x27;"],
         ['\\/', '&#x2F;'],

--- a/dist/commonjs/funcs-html.js
+++ b/dist/commonjs/funcs-html.js
@@ -49,29 +49,87 @@ function encodeLink(str) {
 exports.encodeLink = encodeLink;
 function encodeMappings(mtype) {
     var maps = [
-        ['&', '&amp;'],
-        ['"', '&quot;'],
-        ["'", "&#x27;"],
-        ['\\/', '&#x2F;'],
-        ['\\(', '&#40;'],
-        ['\\)', '&#41;']
+        {
+            url: true,
+            html: true,
+            encodeTo: '&amp;',
+            encodeMatch: '&amp;',
+            decodeTo: '&',
+            decodeMatch: '&'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '&lt;$1',
+            encodeMatch: '&lt;',
+            decodeTo: '<',
+            decodeMatch: '<([^%])'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '$1&gt;',
+            encodeMatch: '&gt;',
+            decodeTo: '>',
+            decodeMatch: '([^%])>'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '&quot;',
+            encodeMatch: '&quot;',
+            decodeTo: '"',
+            decodeMatch: '"'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '&#x27;',
+            encodeMatch: '&#x27;',
+            decodeTo: "'",
+            decodeMatch: "'"
+        },
+        {
+            url: false,
+            html: true,
+            encodeTo: '&#x2F;',
+            encodeMatch: '&#x2F;',
+            decodeTo: '/',
+            decodeMatch: '/'
+        },
+        {
+            url: true,
+            html: false,
+            encodeTo: '&#40;',
+            encodeMatch: '&#40;',
+            decodeTo: '(',
+            decodeMatch: '\\('
+        },
+        {
+            url: true,
+            html: false,
+            encodeTo: '&#41;',
+            encodeMatch: '&#41;',
+            decodeTo: ')',
+            decodeMatch: '\\)'
+        }
     ];
     if (mtype === EncodeTarget.Html) {
         return maps.filter(function (_a) {
-            var v = _a[0], _ = _a[1];
-            return v.indexOf('(') === -1 && v.indexOf(')') === -1;
+            var html = _a.html;
+            return html;
         });
     }
     else {
         return maps.filter(function (_a) {
-            var v = _a[0], _ = _a[1];
-            return v.indexOf('/') === -1;
+            var url = _a.url;
+            return url;
         });
     }
 }
 function encodeMapping(str, mapping) {
-    return str.replace(new RegExp(mapping[0], 'g'), mapping[1]);
+    return str.replace(new RegExp(mapping.decodeMatch, 'g'), mapping.encodeTo);
 }
 function decodeMapping(str, mapping) {
-    return str.replace(new RegExp(mapping[1], 'g'), mapping[0].replace('\\', ''));
+    return str.replace(new RegExp(mapping.encodeMatch, 'g'), mapping.decodeTo);
 }

--- a/dist/commonjs/helpers/url.d.ts
+++ b/dist/commonjs/helpers/url.d.ts
@@ -1,2 +1,2 @@
-declare function sanitize(str: string): string;
+declare function sanitize(str: string, urlWhiteListExtensions?: string[]): string;
 export { sanitize };

--- a/dist/commonjs/helpers/url.js
+++ b/dist/commonjs/helpers/url.js
@@ -1,9 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-function sanitize(str) {
+function sanitize(str, urlWhiteListExtensions) {
     var val = str;
     val = val.replace(/^\s*/gm, '');
-    var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|#|\/|data:image\/)/;
+    var whiteList = new RegExp("^s*((|https?|s?ftp|file|blob|mailto|tel):" + (urlWhiteListExtensions ? '|' + urlWhiteListExtensions.join('|') : '') + "|#|/|data:image/)");
     if (whiteList.test(val)) {
         return val;
     }

--- a/dist/commonjs/helpers/url.js
+++ b/dist/commonjs/helpers/url.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 function sanitize(str) {
     var val = str;
     val = val.replace(/^\s*/gm, '');
-    var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|<%|#|\/|data:image\/)/;
+    var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|#|\/|data:image\/)/;
     if (whiteList.test(val)) {
         return val;
     }

--- a/dist/commonjs/helpers/url.js
+++ b/dist/commonjs/helpers/url.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 function sanitize(str) {
     var val = str;
     val = val.replace(/^\s*/gm, '');
-    var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|#|\/|data:image\/)/;
+    var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|<%|#|\/|data:image\/)/;
     if (whiteList.test(val)) {
         return val;
     }

--- a/dist/commonjs/mentions/MentionSanitizer.d.ts
+++ b/dist/commonjs/mentions/MentionSanitizer.d.ts
@@ -9,7 +9,7 @@ interface IMention {
     'end-point'?: string;
 }
 declare class MentionSanitizer {
-    static sanitize(dirtyObj: IMention): IMention;
+    static sanitize(dirtyObj: IMention, urlWhiteListExtensions?: string[]): IMention;
     static IsValidClass(classAttr: string): boolean;
     static IsValidId(idAttr: string): boolean;
     static IsValidTarget(target: string): boolean;

--- a/dist/commonjs/mentions/MentionSanitizer.js
+++ b/dist/commonjs/mentions/MentionSanitizer.js
@@ -4,7 +4,7 @@ var url = require("./../helpers/url");
 var MentionSanitizer = (function () {
     function MentionSanitizer() {
     }
-    MentionSanitizer.sanitize = function (dirtyObj) {
+    MentionSanitizer.sanitize = function (dirtyObj, urlWhiteListExtensions) {
         var cleanObj = {};
         if (!dirtyObj || typeof dirtyObj !== 'object') {
             return cleanObj;
@@ -19,10 +19,10 @@ var MentionSanitizer = (function () {
             cleanObj.target = dirtyObj.target;
         }
         if (dirtyObj.avatar) {
-            cleanObj.avatar = url.sanitize(dirtyObj.avatar + '');
+            cleanObj.avatar = url.sanitize(dirtyObj.avatar + '', urlWhiteListExtensions);
         }
         if (dirtyObj['end-point']) {
-            cleanObj['end-point'] = url.sanitize(dirtyObj['end-point'] + '');
+            cleanObj['end-point'] = url.sanitize(dirtyObj['end-point'] + '', urlWhiteListExtensions);
         }
         if (dirtyObj.slug) {
             cleanObj.slug = (dirtyObj.slug + '');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-delta-to-html",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Converts Quill's delta ops to HTML",
   "main": "./dist/commonjs/main.js",
   "types": "./dist/commonjs/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "@types/mocha": "^2.2.40",
     "@types/node": "^7.0.12",
+    "browserify": "^16.2.3",
     "coveralls": "^2.13.0",
     "mocha": "^3.2.0",
     "nyc": "^12.0.2",

--- a/src/InsertOpsConverter.ts
+++ b/src/InsertOpsConverter.ts
@@ -10,7 +10,7 @@ import { InsertOpDenormalizer } from './InsertOpDenormalizer';
  */
 class InsertOpsConverter {
 
-    static convert(deltaOps: null | any[]): DeltaInsertOp[] {
+    static convert(deltaOps: null | any[], urlWhiteListExtensions?: string[]): DeltaInsertOp[] {
 
         if (!Array.isArray(deltaOps)) {
             return [];
@@ -32,7 +32,7 @@ class InsertOpsConverter {
                 continue;
             }
 
-            attributes =  OpAttributeSanitizer.sanitize(op.attributes);
+            attributes =  OpAttributeSanitizer.sanitize(op.attributes, urlWhiteListExtensions);
 
             results.push(new DeltaInsertOp(insertVal, attributes));
         }

--- a/src/OpAttributeSanitizer.ts
+++ b/src/OpAttributeSanitizer.ts
@@ -38,7 +38,7 @@ interface IOpAttributes {
 
 class OpAttributeSanitizer {
 
-   static sanitize(dirtyAttrs: IOpAttributes): IOpAttributes {
+   static sanitize(dirtyAttrs: IOpAttributes, urlWhiteListExtensions?: string[]): IOpAttributes {
 
       var cleanAttrs: any = {};
 
@@ -89,7 +89,7 @@ class OpAttributeSanitizer {
       }
 
       if (link) {
-         cleanAttrs.link = url.sanitize(link + '');
+         cleanAttrs.link = url.sanitize(link + '', urlWhiteListExtensions);
       }
       if (target && OpAttributeSanitizer.isValidTarget(target)) {
          cleanAttrs.target = target;
@@ -120,7 +120,7 @@ class OpAttributeSanitizer {
       }
 
       if (mentions && mention) {
-         let sanitizedMention = MentionSanitizer.sanitize(mention);
+         let sanitizedMention = MentionSanitizer.sanitize(mention, urlWhiteListExtensions);
          if (Object.keys(sanitizedMention).length > 0) {
             cleanAttrs.mentions = !!mentions;
             cleanAttrs.mention = mention;

--- a/src/OpToHtmlConverter.ts
+++ b/src/OpToHtmlConverter.ts
@@ -51,7 +51,8 @@ interface IOpToHtmlConverterOptions {
    paragraphTag?: string,
    linkRel?: string,
    linkTarget?: string,
-   allowBackgroundClasses?: boolean
+   allowBackgroundClasses?: boolean,
+   encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[]
 }
 
 interface IHtmlParts {
@@ -128,7 +129,7 @@ class OpToHtmlConverter {
 
       var content = this.op.isFormula() || this.op.isText() ? this.op.insert.value : '';
 
-      return this.options.encodeHtml && encodeHtml(content) || content;
+      return this.options.encodeHtml && encodeHtml(content, undefined, this.options.encodeMapExtensions) || content;
    }
 
    getCssClasses(): string[] {
@@ -236,7 +237,7 @@ class OpToHtmlConverter {
          }
          if (mention['end-point'] && mention.slug) {
             tagAttrs = tagAttrs.concat(
-               makeAttr('href', encodeLink(mention['end-point'] + '/' + mention.slug))
+               makeAttr('href', encodeLink(mention['end-point'] + '/' + mention.slug, this.options.encodeMapExtensions))
             );
          } else {
             tagAttrs = tagAttrs.concat(makeAttr('href', 'about:blank'));
@@ -257,7 +258,7 @@ class OpToHtmlConverter {
       if (this.op.isLink()) {
          let target = this.op.attributes.target || this.options.linkTarget;
          tagAttrs = tagAttrs
-         .concat(makeAttr('href', encodeLink(this.op.attributes.link!)))
+         .concat(makeAttr('href', encodeLink(this.op.attributes.link!, this.options.encodeMapExtensions)))
          .concat(target ? makeAttr('target', target) : []);
          if (!!this.options.linkRel && OpToHtmlConverter.IsValidRel(this.options.linkRel)) {
             tagAttrs.push(makeAttr('rel', this.options.linkRel));

--- a/src/OpToHtmlConverter.ts
+++ b/src/OpToHtmlConverter.ts
@@ -52,7 +52,8 @@ interface IOpToHtmlConverterOptions {
    linkRel?: string,
    linkTarget?: string,
    allowBackgroundClasses?: boolean,
-   encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[]
+   encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[],
+   urlWhiteListExtensions?: string[]
 }
 
 interface IHtmlParts {
@@ -211,7 +212,7 @@ class OpToHtmlConverter {
 
       if (this.op.isImage()) {
          this.op.attributes.width && (tagAttrs = tagAttrs.concat(makeAttr('width', this.op.attributes.width)));
-         return tagAttrs.concat(makeAttr('src', url.sanitize(this.op.insert.value + '')+''));
+         return tagAttrs.concat(makeAttr('src', url.sanitize(this.op.insert.value + '', this.options.urlWhiteListExtensions)+''));
       }
 
       if (this.op.isACheckList()) {
@@ -226,7 +227,7 @@ class OpToHtmlConverter {
          return tagAttrs.concat(
             makeAttr('frameborder', '0'),
             makeAttr('allowfullscreen', 'true'),
-            makeAttr('src', url.sanitize(this.op.insert.value + '')+'')
+            makeAttr('src', url.sanitize(this.op.insert.value + '', this.options.urlWhiteListExtensions)+'')
          );
       }
 

--- a/src/OpToHtmlConverter.ts
+++ b/src/OpToHtmlConverter.ts
@@ -1,4 +1,4 @@
-import { makeStartTag, makeEndTag, encodeHtml, encodeLink, ITagKeyValue } from './funcs-html';
+import { makeStartTag, makeEndTag, encodeHtml, encodeLink, ITagKeyValue, IEncodeMapExtension } from './funcs-html';
 import { DeltaInsertOp } from './DeltaInsertOp';
 import { ScriptType, NewLine } from './value-types';
 import * as url from './helpers/url';
@@ -52,7 +52,7 @@ interface IOpToHtmlConverterOptions {
    linkRel?: string,
    linkTarget?: string,
    allowBackgroundClasses?: boolean,
-   encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[],
+   encodeMapExtensions?: IEncodeMapExtension[],
    urlWhiteListExtensions?: string[]
 }
 

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -7,7 +7,7 @@ import {
    VideoItem, InlineGroup, BlockGroup, ListGroup, ListItem, TDataGroup, BlotBlock
 } from './grouper/group-types';
 import { ListNester } from './grouper/ListNester';
-import { makeStartTag, makeEndTag, encodeHtml } from './funcs-html';
+import { makeStartTag, makeEndTag, encodeHtml, IEncodeMapExtension } from './funcs-html';
 import * as obj from './helpers/object';
 import { GroupType } from './value-types';
 
@@ -30,7 +30,7 @@ interface IQuillDeltaToHtmlConverterOptions {
    linkRel?: string,
    linkTarget?: string,
    allowBackgroundClasses?: boolean,
-   encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[],
+   encodeMapExtensions?: IEncodeMapExtension[],
    urlWhiteListExtensions?: string[]
 }
 

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -29,7 +29,8 @@ interface IQuillDeltaToHtmlConverterOptions {
 
    linkRel?: string,
    linkTarget?: string,
-   allowBackgroundClasses?: boolean
+   allowBackgroundClasses?: boolean,
+   encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[]
 }
 
 const BrTag = '<br/>';
@@ -81,7 +82,8 @@ class QuillDeltaToHtmlConverter {
          paragraphTag: this.options.paragraphTag,
          linkRel: this.options.linkRel,
          linkTarget: this.options.linkTarget,
-         allowBackgroundClasses: this.options.allowBackgroundClasses
+         allowBackgroundClasses: this.options.allowBackgroundClasses,
+         encodeMapExtensions: this.options.encodeMapExtensions
       };
       this.rawDeltaOps = deltaOps;
 

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -30,7 +30,8 @@ interface IQuillDeltaToHtmlConverterOptions {
    linkRel?: string,
    linkTarget?: string,
    allowBackgroundClasses?: boolean,
-   encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[]
+   encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[],
+   urlWhiteListExtensions?: string[]
 }
 
 const BrTag = '<br/>';
@@ -83,7 +84,8 @@ class QuillDeltaToHtmlConverter {
          linkRel: this.options.linkRel,
          linkTarget: this.options.linkTarget,
          allowBackgroundClasses: this.options.allowBackgroundClasses,
-         encodeMapExtensions: this.options.encodeMapExtensions
+         encodeMapExtensions: this.options.encodeMapExtensions,
+         urlWhiteListExtensions: this.options.urlWhiteListExtensions
       };
       this.rawDeltaOps = deltaOps;
 
@@ -98,7 +100,7 @@ class QuillDeltaToHtmlConverter {
    }
 
    getGroupedOps(): TDataGroup[] {
-      var deltaOps = InsertOpsConverter.convert(this.rawDeltaOps);
+      var deltaOps = InsertOpsConverter.convert(this.rawDeltaOps, this.options.urlWhiteListExtensions);
 
       var pairedOps = Grouper.pairOpsWithTheirBlock(deltaOps);
 

--- a/src/funcs-html.ts
+++ b/src/funcs-html.ts
@@ -51,30 +51,83 @@ function encodeLink(str: string) {
 
 function encodeMappings(mtype: EncodeTarget) {
     let maps = [
-        ['&', '&amp;'], 
-        // ['<', '&lt;'],
-        // ['>', '&gt;'],
-        ['"', '&quot;'],
-        ["'", "&#x27;"],
-        ['\\/', '&#x2F;'],
-        ['\\(', '&#40;'],
-        ['\\)', '&#41;']
+        {
+            url: true,
+            html: true,
+            encodeTo: '&amp;',
+            encodeMatch: '&amp;',
+            decodeTo: '&',
+            decodeMatch: '&'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '&lt;$1',
+            encodeMatch: '&lt;',
+            decodeTo: '<',
+            decodeMatch: '<([^%])'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '$1&gt;',
+            encodeMatch: '&gt;',
+            decodeTo: '>',
+            decodeMatch: '([^%])>'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '&quot;',
+            encodeMatch: '&quot;',
+            decodeTo: '"',
+            decodeMatch: '"'
+        },
+        {
+            url: true,
+            html: true,
+            encodeTo: '&#x27;',
+            encodeMatch: '&#x27;',
+            decodeTo: "'",
+            decodeMatch: "'"
+        },
+        {
+            url: false,
+            html: true,
+            encodeTo: '&#x2F;',
+            encodeMatch: '&#x2F;',
+            decodeTo: '/',
+            decodeMatch: '/'
+        },
+        {
+            url: true,
+            html: false,
+            encodeTo: '&#40;',
+            encodeMatch: '&#40;',
+            decodeTo: '(',
+            decodeMatch: '\\('
+        },
+        {  
+            url: true,
+            html: false,
+            encodeTo: '&#41;',
+            encodeMatch: '&#41;',
+            decodeTo: ')',
+            decodeMatch: '\\)'
+        }
     ];
+
     if (mtype === EncodeTarget.Html) {
-        return maps.filter(([v,_]) => 
-            v.indexOf('(') === -1 && v.indexOf(')') === -1
-        );
+        return maps.filter(({html}) =>  html);
     } else { // for url
-        return maps.filter(([v,_]) => v.indexOf('/') === -1);
+        return maps.filter(({url}) =>  url);
     }
 }
-function encodeMapping(str: string, mapping: string[]) {
-    return str.replace(new RegExp(mapping[0], 'g'), mapping[1]);
+function encodeMapping(str: string, mapping: { decodeMatch: string, encodeTo: string }) {
+    return str.replace(new RegExp(mapping.decodeMatch, 'g'), mapping.encodeTo);
 }
-function decodeMapping(str: string, mapping: string[]) {
-    return str.replace(
-        new RegExp(mapping[1], 'g'), mapping[0].replace('\\','')
-    );
+function decodeMapping(str: string, mapping: { encodeMatch: string, decodeTo: string }) {
+    return str.replace(new RegExp(mapping.encodeMatch, 'g'), mapping.decodeTo);
 }
 export {
     makeStartTag,

--- a/src/funcs-html.ts
+++ b/src/funcs-html.ts
@@ -52,8 +52,8 @@ function encodeLink(str: string) {
 function encodeMappings(mtype: EncodeTarget) {
     let maps = [
         ['&', '&amp;'], 
-        ['<', '&lt;'],
-        ['>', '&gt;'],
+        // ['<', '&lt;'],
+        // ['>', '&gt;'],
         ['"', '&quot;'],
         ["'", "&#x27;"],
         ['\\/', '&#x2F;'],

--- a/src/funcs-html.ts
+++ b/src/funcs-html.ts
@@ -4,6 +4,16 @@ interface ITagKeyValue {
     value?: string
 }
 
+interface IEncodeMapExtension {
+    key: string, 
+    url: boolean, 
+    html: boolean, 
+    encodeTo: string, 
+    encodeMatch: string, 
+    decodeTo: string, 
+    decodeMatch: string
+}
+
 enum EncodeTarget {
     Html = 0,
     Url = 1
@@ -32,24 +42,24 @@ function makeEndTag(tag: any = '') {
     return tag && `</${tag}>` || '';
 }
 
-function decodeHtml(str: string, encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[]) {
+function decodeHtml(str: string, encodeMapExtensions?: IEncodeMapExtension[]) {
     return encodeMappings(EncodeTarget.Html, encodeMapExtensions).reduce(decodeMapping, str);
 }
 
-function encodeHtml(str: string, preventDoubleEncoding = true, encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[]) {
+function encodeHtml(str: string, preventDoubleEncoding = true, encodeMapExtensions?: IEncodeMapExtension[]) {
     if (preventDoubleEncoding) {
         str = decodeHtml(str, encodeMapExtensions);
     }
     return encodeMappings(EncodeTarget.Html, encodeMapExtensions).reduce(encodeMapping, str);
 }
 
-function encodeLink(str: string, encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[]) {
+function encodeLink(str: string, encodeMapExtensions?: IEncodeMapExtension[]) {
     let linkMaps = encodeMappings(EncodeTarget.Url, encodeMapExtensions);
     let decoded = linkMaps.reduce(decodeMapping, str);
     return linkMaps.reduce(encodeMapping, decoded);
 }
 
-function encodeMappings(mtype: EncodeTarget, encodeMapExtensions?: { key: string, url: boolean, html: boolean, encodeTo: string, encodeMatch: string, decodeTo: string, decodeMatch: string }[]) {
+function encodeMappings(mtype: EncodeTarget, encodeMapExtensions?: IEncodeMapExtension[]) {
     let maps = [
         {
             key: '&',
@@ -161,10 +171,10 @@ function encodeMappings(mtype: EncodeTarget, encodeMapExtensions?: { key: string
         return maps.filter(({url}) =>  url);
     }
 }
-function encodeMapping(str: string, mapping: { decodeMatch: string, encodeTo: string }) {
+function encodeMapping(str: string, mapping: IEncodeMapExtension) {
     return str.replace(new RegExp(mapping.decodeMatch, 'g'), mapping.encodeTo);
 }
-function decodeMapping(str: string, mapping: { encodeMatch: string, decodeTo: string }) {
+function decodeMapping(str: string, mapping: IEncodeMapExtension) {
     return str.replace(new RegExp(mapping.encodeMatch, 'g'), mapping.decodeTo);
 }
 export {
@@ -173,5 +183,6 @@ export {
     encodeHtml,
     decodeHtml,
     encodeLink,
-    ITagKeyValue
+    ITagKeyValue,
+    IEncodeMapExtension
 };

--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -1,7 +1,7 @@
 function sanitize(str: string): string {
    let val = str;
    val = val.replace(/^\s*/gm, '')
-   let whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|#|\/|data:image\/)/;
+   var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|<%|#|\/|data:image\/)/;
    if (whiteList.test(val)) {
       return val;
    }

--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -1,7 +1,7 @@
-function sanitize(str: string): string {
+function sanitize(str: string, urlWhiteListExtensions?: string[]): string {
    let val = str;
    val = val.replace(/^\s*/gm, '')
-   var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|#|\/|data:image\/)/;
+   let whiteList = new RegExp(`^\s*((|https?|s?ftp|file|blob|mailto|tel):${urlWhiteListExtensions ? '|' + urlWhiteListExtensions.join('|') : ''}|#|\/|data:image\/)`)
    if (whiteList.test(val)) {
       return val;
    }

--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -1,7 +1,7 @@
 function sanitize(str: string): string {
    let val = str;
    val = val.replace(/^\s*/gm, '')
-   var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|<%|#|\/|data:image\/)/;
+   var whiteList = /^\s*((|https?|s?ftp|file|blob|mailto|tel):|#|\/|data:image\/)/;
    if (whiteList.test(val)) {
       return val;
    }

--- a/src/mentions/MentionSanitizer.ts
+++ b/src/mentions/MentionSanitizer.ts
@@ -14,7 +14,7 @@ interface IMention {
 
 class MentionSanitizer {
 
-   static sanitize(dirtyObj: IMention): IMention {
+   static sanitize(dirtyObj: IMention, urlWhiteListExtensions?: string[]): IMention {
 
       var cleanObj: any = {};
 
@@ -35,11 +35,11 @@ class MentionSanitizer {
       }
 
       if (dirtyObj.avatar) {
-         cleanObj.avatar = url.sanitize(dirtyObj.avatar + '');
+         cleanObj.avatar = url.sanitize(dirtyObj.avatar + '', urlWhiteListExtensions);
       }
 
       if (dirtyObj['end-point']) {
-         cleanObj['end-point'] = url.sanitize(dirtyObj['end-point'] + '');
+         cleanObj['end-point'] = url.sanitize(dirtyObj['end-point'] + '', urlWhiteListExtensions);
       }
 
       if (dirtyObj.slug) {

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -126,14 +126,27 @@ describe('QuillDeltaToHtmlConverter', function () {
       });
 
       it('should create checked/unchecked lists', function () {
-         var ops4 = [
-            { insert: "something", attributes: { link: '<%= something.me %>.com' } },
-         ]
-         var qdc = new QuillDeltaToHtmlConverter(ops4);
-         var html = qdc.convert();
-         assert.equal(html, [
-            '<p><a href="<%= something.me %>.com" target="_blank">something</a></p>'
-         ].join(''));
+          var ops4 = [
+             { insert: "hello" },
+             { insert: "\n", attributes: { list: 'checked' } },
+             { insert: "there" },
+             { insert: "\n", attributes: { list: 'unchecked' } },
+             { insert: "man" },
+             { insert: "\n", attributes: { list: 'checked' } },
+             { insert: 'not done'},
+             { insert: "\n", attributes: {indent:1, list: 'unchecked'}}
+          ]
+          var qdc = new QuillDeltaToHtmlConverter(ops4);
+          var html = qdc.convert();
+          assert.equal(html, [
+             '<ul>',
+             '<li data-checked="true">hello</li>',
+             '<li data-checked="false">there</li>',
+             '<li data-checked="true">man',
+                '<ul><li data-checked="false">not done</li></ul>',
+             '</li>',
+             '</ul>'
+          ].join(''));
       });
 
       it('should wrap positional styles in right tag', function () {

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -202,7 +202,7 @@ describe('QuillDeltaToHtmlConverter', function () {
           let ops = [
               { "attributes": { "target": "_self", "link": "<%=my.template%>.com" }, "insert": "A" }
           ];
-          let qdc = new QuillDeltaToHtmlConverter(ops, {encodeMapExtensions: [
+          let qdc = new QuillDeltaToHtmlConverter(ops, { urlWhiteListExtensions: ['<%'], encodeMapExtensions: [
             {
                 key: '<',
                 url: true,

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -125,7 +125,7 @@ describe('QuillDeltaToHtmlConverter', function () {
          assert.equal(html, '<p>hello</p><p>how areyou?</p><p><br/></p><p>bye</p>');
       });
 
-      it.only('should create checked/unchecked lists', function () {
+      it('should create checked/unchecked lists', function () {
          var ops4 = [
             { insert: "something", attributes: { link: '<%= something.me %>.com' } },
          ]

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -198,9 +198,9 @@ describe('QuillDeltaToHtmlConverter', function () {
             `<a href="http://#" target="_top">C</a></p>`
          ].join(''));
       });
-      it('should render target attr correctly', () => {
+      it('should render template href', () => {
           let ops = [
-              { "attributes": { "target": "_self", "link": "http://<%=my.template%>.com" }, "insert": "A" }
+              { "attributes": { "target": "_self", "link": "<%=my.template%>.com" }, "insert": "A" }
           ];
           let qdc = new QuillDeltaToHtmlConverter(ops, {encodeMapExtensions: [
             {
@@ -224,7 +224,7 @@ describe('QuillDeltaToHtmlConverter', function () {
         ]});
           let html = qdc.convert();
           assert.equal(html, [
-             `<p><a href="http://<%=my.template%>.com" target="_self">A</a></p>`
+             `<p><a href="<%=my.template%>.com" target="_self">A</a></p>`
           ].join(''));
       });
    });

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -125,27 +125,14 @@ describe('QuillDeltaToHtmlConverter', function () {
          assert.equal(html, '<p>hello</p><p>how areyou?</p><p><br/></p><p>bye</p>');
       });
 
-      it('should create checked/unchecked lists', function () {
+      it.only('should create checked/unchecked lists', function () {
          var ops4 = [
-            { insert: "hello" },
-            { insert: "\n", attributes: { list: 'checked' } },
-            { insert: "there" },
-            { insert: "\n", attributes: { list: 'unchecked' } },
-            { insert: "man" },
-            { insert: "\n", attributes: { list: 'checked' } },
-            { insert: 'not done'},
-            { insert: "\n", attributes: {indent:1, list: 'unchecked'}}
+            { insert: "something", attributes: { link: '<%= something.me %>.com' } },
          ]
          var qdc = new QuillDeltaToHtmlConverter(ops4);
          var html = qdc.convert();
          assert.equal(html, [
-            '<ul>',
-            '<li data-checked="true">hello</li>',
-            '<li data-checked="false">there</li>',
-            '<li data-checked="true">man',
-               '<ul><li data-checked="false">not done</li></ul>',
-            '</li>',
-            '</ul>'
+            '<p><a href="<%= something.me %>.com" target="_blank">something</a></p>'
          ].join(''));
       });
 

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -198,6 +198,35 @@ describe('QuillDeltaToHtmlConverter', function () {
             `<a href="http://#" target="_top">C</a></p>`
          ].join(''));
       });
+      it('should render target attr correctly', () => {
+          let ops = [
+              { "attributes": { "target": "_self", "link": "http://<%=my.template%>.com" }, "insert": "A" }
+          ];
+          let qdc = new QuillDeltaToHtmlConverter(ops, {encodeMapExtensions: [
+            {
+                key: '<',
+                url: true,
+                html: true,
+                encodeTo: '&lt;$1',
+                encodeMatch: '&lt;',
+                decodeTo: '<',
+                decodeMatch: '<([^%])'
+            },
+            {
+                key: '>',
+                url: true,
+                html: true,
+                encodeTo: '$1&gt;',
+                encodeMatch: '&gt;',
+                decodeTo: '>',
+                decodeMatch: '([^%])>'
+            }
+        ]});
+          let html = qdc.convert();
+          assert.equal(html, [
+             `<p><a href="http://<%=my.template%>.com" target="_self">A</a></p>`
+          ].join(''));
+      });
    });
 
    describe('custom types', () => {

--- a/test/funcs-html.test.ts
+++ b/test/funcs-html.test.ts
@@ -51,7 +51,7 @@ describe('html module', function () {
     });
 
     describe('encodeHtml()', function () {
-        it.skip('should encode < > & " \' / characters', function() {
+        it('should encode < > & " \' / characters', function() {
 
             var act = encodeHtml('hello"my<lovely\'/>&amp;friend&here()', false);
             assert.equal(act, 'hello&quot;my&lt;lovely&#x27;&#x2F;&gt;&amp;amp;friend&amp;here()');

--- a/test/funcs-html.test.ts
+++ b/test/funcs-html.test.ts
@@ -51,13 +51,22 @@ describe('html module', function () {
     });
 
     describe('encodeHtml()', function () {
-        it('should encode < > & " \' / characters', function() {
+        it.skip('should encode < > & " \' / characters', function() {
 
             var act = encodeHtml('hello"my<lovely\'/>&amp;friend&here()', false);
             assert.equal(act, 'hello&quot;my&lt;lovely&#x27;&#x2F;&gt;&amp;amp;friend&amp;here()');
 
             var act = encodeHtml('hello"my<lovely\'/>&amp;friend&here()');
             assert.equal(act, 'hello&quot;my&lt;lovely&#x27;&#x2F;&gt;&amp;friend&amp;here()');
+        });
+
+        it('should not encode < > characters', function() {
+
+            var act = encodeHtml('<%= ocsadf.coamf %>', false);
+            assert.equal(act, '<%= ocsadf.coamf %>');
+
+            // var act = encodeHtml('hello"my<lovely\'/>&amp;friend&here()');
+            // assert.equal(act, 'hello&quot;my&lt;lovely&#x27;&#x2F;&gt;&amp;friend&amp;here()');
         });
     });
 

--- a/test/funcs-html.test.ts
+++ b/test/funcs-html.test.ts
@@ -60,13 +60,10 @@ describe('html module', function () {
             assert.equal(act, 'hello&quot;my&lt;lovely&#x27;&#x2F;&gt;&amp;friend&amp;here()');
         });
 
-        it('should not encode < > characters', function() {
+        it('should not encode <% %> characters', function() {
 
-            var act = encodeHtml('<%= ocsadf.coamf %>', false);
-            assert.equal(act, '<%= ocsadf.coamf %>');
-
-            // var act = encodeHtml('hello"my<lovely\'/>&amp;friend&here()');
-            // assert.equal(act, 'hello&quot;my&lt;lovely&#x27;&#x2F;&gt;&amp;friend&amp;here()');
+            var act = encodeHtml('<%= my.template %>', false);
+            assert.equal(act, '<%= my.template %>');
         });
     });
 

--- a/test/funcs-html.test.ts
+++ b/test/funcs-html.test.ts
@@ -60,9 +60,29 @@ describe('html module', function () {
             assert.equal(act, 'hello&quot;my&lt;lovely&#x27;&#x2F;&gt;&amp;friend&amp;here()');
         });
 
-        it('should not encode <% %> characters', function() {
+        it('should respect characters in encodeMapExtensions ', function() {
 
-            var act = encodeHtml('<%= my.template %>', false);
+            var act = encodeHtml('<%= my.template %>', false, [
+                {
+                    key: '<',
+                    url: true,
+                    html: true,
+                    encodeTo: '&lt;$1',
+                    encodeMatch: '&lt;',
+                    decodeTo: '<',
+                    decodeMatch: '<([^%])'
+                },
+                {
+                    key: '>',
+                    url: true,
+                    html: true,
+                    encodeTo: '$1&gt;',
+                    encodeMatch: '&gt;',
+                    decodeTo: '>',
+                    decodeMatch: '([^%])>'
+                }
+            ]);
+
             assert.equal(act, '<%= my.template %>');
         });
     });
@@ -74,6 +94,31 @@ describe('html module', function () {
             assert.equal(act, 'hello"my<lovely\'/>&friend&here');
 
         });
+
+        it('should respect characters in encodeMapExtensions ', function() {
+
+            var act = decodeHtml('hello&quot;my&lt;lovely&#x27;&#x2F;&gt;&amp;<%= my.template %>&amp;here', [
+                {
+                    key: '<',
+                    url: true,
+                    html: true,
+                    encodeTo: '&lt;$1',
+                    encodeMatch: '&lt;',
+                    decodeTo: '<',
+                    decodeMatch: '<([^%])'
+                },
+                {
+                    key: '>',
+                    url: true,
+                    html: true,
+                    encodeTo: '$1&gt;',
+                    encodeMatch: '&gt;',
+                    decodeTo: '>',
+                    decodeMatch: '([^%])>'
+                }
+            ]);
+            assert.equal(act, 'hello"my<lovely\'/>&<%= my.template %>&here');
+        });
     });
 
     describe('encodeLink()', function () {
@@ -81,6 +126,32 @@ describe('html module', function () {
 
             var act = encodeLink('http://www.yahoo.com/?a=b&c=<>()"\'');
             assert.equal(act, 'http://www.yahoo.com/?a=b&amp;c=&lt;&gt;&#40;&#41;&quot;&#x27;');
+
+        });
+
+        it('should encode link while respecting encodeMapExtensions', function() {
+
+            var act = encodeLink('http://<%= my.template %>/?a=b&c=<>()"\'', [
+                {
+                    key: '<',
+                    url: true,
+                    html: true,
+                    encodeTo: '&lt;$1',
+                    encodeMatch: '&lt;',
+                    decodeTo: '<',
+                    decodeMatch: '<([^%])'
+                },
+                {
+                    key: '>',
+                    url: true,
+                    html: true,
+                    encodeTo: '$1&gt;',
+                    encodeMatch: '&gt;',
+                    decodeTo: '>',
+                    decodeMatch: '([^%])>'
+                }
+            ]);
+            assert.equal(act, 'http://<%= my.template %>/?a=b&amp;c=&lt;&gt;&#40;&#41;&quot;&#x27;');
 
         });
     });

--- a/test/helpers/url.test.ts
+++ b/test/helpers/url.test.ts
@@ -12,8 +12,8 @@ describe("Url Helpers Module", function(){
             var act = "http://www><.yahoo'.com";
             assert.equal(sanitize(act), "http://www><.yahoo'.com");
 
-            act = "http://www<%=yahoo%>'.com";
-            assert.equal(sanitize(act), "http://www<%=yahoo%>'.com");
+            act = "http://www.<%= yahoo %>.com";
+            assert.equal(sanitize(act), "http://www.<%= yahoo %>.com");
 
             act = "https://abc";
             assert.equal(sanitize(act), "https://abc");

--- a/test/helpers/url.test.ts
+++ b/test/helpers/url.test.ts
@@ -12,6 +12,9 @@ describe("Url Helpers Module", function(){
             var act = "http://www><.yahoo'.com";
             assert.equal(sanitize(act), "http://www><.yahoo'.com");
 
+            act = "http://www<%=yahoo%>'.com";
+            assert.equal(sanitize(act), "http://www<%=yahoo%>'.com");
+
             act = "https://abc";
             assert.equal(sanitize(act), "https://abc");
 


### PR DESCRIPTION
## Motivation
My team and I have implemented a custom templating language to allow for variables to be resolved server side in a template.  For example, the UI can supply `<%= content.name %> hello!` and return the string `Bob hello!`. We made a custom quill add on to make this a nice experience for the user.  With this functionality we wanted to be able to create links that use templated href's for example:
`<a href="<%= content.url %>">Click me</a>`

Before this pull request the href would be sanitized and unusable for us.

## Approach to a solution
First we needed the ability to add to the URL sanitize white list to allow urls to start with `<%` for our case.
Second we needed the ability to customize the encoding map to not encode `<` or `>` if they are paired with a `%`

I added options for both new requirements to be supplied by a user.  

## Tests
Added a few new tests to exercise my use case

## Notes
- This is my first time using TypeScript so go easy on me.
- Any feedback welcome would love to stay on the main branch of this repo and get off my fork