### PR TITLE
opt:do not disable class generating

### DIFF
--- a/src/OpToHtmlConverter.ts
+++ b/src/OpToHtmlConverter.ts
@@ -143,16 +143,12 @@ class OpToHtmlConverter {
 
       type Str2StrType = { (x: string): string };
 
-      if(this.options.inlineStyles) {
-            return [];
-      }
-
       var propsArr = ['indent', 'align', 'direction', 'font', 'size'];
       if (this.options.allowBackgroundClasses) {
          propsArr.push('background');
       }
       return propsArr
-         .filter((prop) => !!attrs[prop])
+         .filter((prop) => !!attrs[prop] && !(this.options.inlineStyles && this.options.inlineStyles.hasOwnProperty(prop)))
          .filter((prop) => prop === 'background' ? OpAttributeSanitizer.IsValidColorLiteral(attrs[prop]) : true)
          .map((prop) => prop + '-' + attrs[prop])
          .concat(this.op.isFormula() ? 'formula' : [])


### PR DESCRIPTION
**css classes** and **css styles** can be used at the same time in web development，they are not against with each other.
**So I think it would be better to comform to this emprical knowledge.**
If I define  a custom handler for background-color in inlineStyles, **the font-size related class (e.g. ql-size-48px) would not generated**.For that, I have to **define another handler for font-size in inlineStyles**.
Although the default font-size class-based handler can totally meet my demand and  I didn't write a handler to overwrite it.