### PR TITLE
Fix: formula output to comply with KaTeX rules

### DIFF
--- a/src/InsertOpsConverter.ts
+++ b/src/InsertOpsConverter.ts
@@ -79,7 +79,12 @@ class InsertOpsConverter {
           )
         )
       : DataType.Formula in insertPropVal
-      ? new InsertDataQuill(DataType.Formula, insertPropVal[DataType.Formula])
+      ? new InsertDataQuill(
+          DataType.Formula,
+          sanitizeOptions.formulaDelimiters.left +
+            insertPropVal[DataType.Formula] +
+            sanitizeOptions.formulaDelimiters.right
+        )
       : // custom
         new InsertDataCustom(keys[0], insertPropVal[keys[0]]);
   }

--- a/src/OpAttributeSanitizer.ts
+++ b/src/OpAttributeSanitizer.ts
@@ -44,6 +44,7 @@ interface IUrlSanitizerFn {
 }
 interface IOpAttributeSanitizerOptions {
   urlSanitizer?: IUrlSanitizerFn;
+  formulaDelimiters: { left: string; right: string };
 }
 
 class OpAttributeSanitizer {

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -62,6 +62,7 @@ class QuillDeltaToHtmlConverter {
         multiLineCustomBlock: true,
         allowBackgroundClasses: false,
         linkTarget: '_blank',
+        formulaDelimiters: { left: '$', right: '$' },
       },
       options,
       {


### PR DESCRIPTION
The library's formula output was not following KaTeX rules, specifically missing delimiter symbols, causing the original LaTeX text to be displayed as is. Added options to customize left and right delimiters for improved compatibility.